### PR TITLE
Find native library path during execution

### DIFF
--- a/cryptlex/lexactivator/lexactivator_native.py
+++ b/cryptlex/lexactivator/lexactivator_native.py
@@ -50,7 +50,10 @@ def get_library_path():
     # Get the working directory of this file
     filename = inspect.getframeinfo(inspect.currentframe()).filename
     dir_path = os.path.dirname(os.path.abspath(filename))
-    # dir_path = os.getcwd()
+
+    if not os.path.exists(dir_path):
+        dir_path = os.path.abspath(os.path.dirname(__file__))
+
     if sys.platform == 'darwin':
         return os.path.join(dir_path, "libs/macos/"+arch+"/libLexActivator.dylib")
     elif sys.platform.startswith('linux'):


### PR DESCRIPTION
We have a module not found error if code is frozen and the library is not in the same path as when it was compiled.
If the application is compiled or frozen (with cx_freeze), inspect module return the path of source file.

https://github.com/cryptlex/lexactivator-python/blob/f94b13d16f2ee38aa586d8389993997f03636791/cryptlex/lexactivator/lexactivator_native.py#L51

I purpose to use compiled opcode path if source path is not found.